### PR TITLE
store: submit matchers along with span

### DIFF
--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1122,6 +1122,8 @@ func (s *BucketStore) Series(req *storepb.SeriesRequest, srv storepb.Store_Serie
 		begin := time.Now()
 		tracing.DoInSpan(ctx, "bucket_store_preload_all", func(_ context.Context) {
 			err = g.Wait()
+		}, tracing.Tags{
+			"matchers": matchers,
 		})
 		if err != nil {
 			code := codes.Aborted


### PR DESCRIPTION
Add the matchers here because it is interesting to know what Select()s
are coming in that result in huge load.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
