### PR TITLE
api: fix race between Respond and query/queryRange

### DIFF
--- a/pkg/api/blocks/v1_test.go
+++ b/pkg/api/blocks/v1_test.go
@@ -71,7 +71,8 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}
 
-		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+		resp, _, apiErr, releaseResources := test.endpoint(req.WithContext(ctx))
+		defer releaseResources()
 		if apiErr != nil {
 			if test.errType == baseAPI.ErrorNone {
 				t.Fatalf("Unexpected error: %s", apiErr)

--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -84,6 +84,7 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 	if err != nil {
 		return err
 	}
+	defer qry.Close()
 
 	result := qry.Exec(ctx)
 	if err := server.Send(querypb.NewQueryWarningsResponse(result.Warnings)); err != nil {
@@ -157,6 +158,7 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 	if err != nil {
 		return err
 	}
+	defer qry.Close()
 
 	result := qry.Exec(ctx)
 	if err := srv.Send(querypb.NewQueryRangeWarningsResponse(result.Warnings)); err != nil {

--- a/pkg/api/query/v1.go
+++ b/pkg/api/query/v1.go
@@ -374,6 +374,7 @@ func (qapi *QueryAPI) query(r *http.Request) (interface{}, []error, *api.ApiErro
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
+	defer qry.Close()
 
 	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
 		err = qapi.gate.Start(ctx)
@@ -502,6 +503,7 @@ func (qapi *QueryAPI) queryRange(r *http.Request) (interface{}, []error, *api.Ap
 	if err != nil {
 		return nil, nil, &api.ApiError{Typ: api.ErrorBadData, Err: err}
 	}
+	defer qry.Close()
 
 	tracing.DoInSpan(ctx, "query_gate_ismyturn", func(ctx context.Context) {
 		err = qapi.gate.Start(ctx)

--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -109,7 +109,8 @@ func testEndpoint(t *testing.T, test endpointTestCase, name string, responseComp
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		}
 
-		resp, _, apiErr := test.endpoint(req.WithContext(ctx))
+		resp, _, apiErr, releaseResources := test.endpoint(req.WithContext(ctx))
+		defer releaseResources()
 		if apiErr != nil {
 			if test.errType == baseAPI.ErrorNone {
 				t.Fatalf("Unexpected error: %s", apiErr)
@@ -1781,7 +1782,8 @@ func TestRulesHandler(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			res, errors, apiError := endpoint(req.WithContext(ctx))
+			res, errors, apiError, releaseResources := endpoint(req.WithContext(ctx))
+			defer releaseResources()
 			if errors != nil {
 				t.Fatalf("Unexpected errors: %s", errors)
 				return

--- a/pkg/api/rule/v1.go
+++ b/pkg/api/rule/v1.go
@@ -57,8 +57,8 @@ func (rapi *RuleAPI) Register(r *route.Router, tracer opentracing.Tracer, logger
 
 	instr := api.GetInstr(tracer, logger, ins, logMiddleware, rapi.disableCORS)
 
-	r.Get("/alerts", instr("alerts", func(r *http.Request) (interface{}, []error, *api.ApiError) {
-		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil
+	r.Get("/alerts", instr("alerts", func(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
+		return struct{ Alerts []*rulespb.AlertInstance }{Alerts: rapi.alerts.Active()}, nil, nil, func() {}
 	}))
 	r.Get("/rules", instr("rules", qapi.NewRulesHandler(rapi.ruleGroups, false)))
 }

--- a/pkg/api/status/v1.go
+++ b/pkg/api/status/v1.go
@@ -68,20 +68,20 @@ func (sapi *StatusAPI) Register(r *route.Router, tracer opentracing.Tracer, logg
 	r.Get("/api/v1/status/tsdb", instr("tsdb_status", sapi.httpServeStats))
 }
 
-func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *api.ApiError) {
+func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *api.ApiError, func()) {
 	stats, sterr := sapi.getTSDBStats(r, labels.MetricName)
 	if sterr != nil {
-		return nil, nil, sterr
+		return nil, nil, sterr, func() {}
 	}
 
 	result := make([]TSDBStatus, 0, len(stats))
 	if len(stats) == 0 {
-		return result, nil, nil
+		return result, nil, nil, func() {}
 	}
 
 	metrics, err := sapi.registry.Gather()
 	if err != nil {
-		return nil, []error{err}, nil
+		return nil, []error{err}, nil, func() {}
 	}
 
 	tenantChunks := make(map[string]int64)
@@ -121,5 +121,5 @@ func (sapi *StatusAPI) httpServeStats(r *http.Request) (interface{}, []error, *a
 			},
 		})
 	}
-	return result, nil, nil
+	return result, nil, nil, func() {}
 }


### PR DESCRIPTION
Let's see if https://github.com/vinted/thanos/commit/64fbc3a84841122a7c62b30732112cf075840d99 helps with issues spotted in production.