### PR TITLE
V0.29.0+vinted patches

### DIFF
--- a/cmd/thanos/sidecar.go
+++ b/cmd/thanos/sidecar.go
@@ -246,7 +246,7 @@ func runSidecar(
 	{
 		c := promclient.NewWithTracingClient(logger, httpClient, httpconfig.ThanosUserAgent)
 
-		promStore, err := store.NewPrometheusStore(logger, reg, c, conf.prometheus.url, component.Sidecar, m.Labels, m.Timestamps, m.Version)
+		promStore, err := store.NewPrometheusStore(logger, reg, c, conf.prometheus.url, component.Sidecar, m.Labels, m.Timestamps, m.Version, conf.limitMaxMatchedSeries)
 		if err != nil {
 			return errors.Wrap(err, "create Prometheus store")
 		}
@@ -474,15 +474,16 @@ func (s *promMetadata) Version() string {
 }
 
 type sidecarConfig struct {
-	http         httpConfig
-	grpc         grpcConfig
-	prometheus   prometheusConfig
-	tsdb         tsdbConfig
-	reloader     reloaderConfig
-	reqLogConfig *extflag.PathOrContent
-	objStore     extflag.PathOrContent
-	shipper      shipperConfig
-	limitMinTime thanosmodel.TimeOrDurationValue
+	http                  httpConfig
+	grpc                  grpcConfig
+	prometheus            prometheusConfig
+	tsdb                  tsdbConfig
+	reloader              reloaderConfig
+	reqLogConfig          *extflag.PathOrContent
+	objStore              extflag.PathOrContent
+	shipper               shipperConfig
+	limitMinTime          thanosmodel.TimeOrDurationValue
+	limitMaxMatchedSeries int
 }
 
 func (sc *sidecarConfig) registerFlag(cmd extkingpin.FlagClause) {
@@ -496,4 +497,5 @@ func (sc *sidecarConfig) registerFlag(cmd extkingpin.FlagClause) {
 	sc.shipper.registerFlag(cmd)
 	cmd.Flag("min-time", "Start of time range limit to serve. Thanos sidecar will serve only metrics, which happened later than this value. Option can be a constant time in RFC3339 format or time duration relative to current time, such as -1d or 2h45m. Valid duration units are ms, s, m, h, d, w, y.").
 		Default("0000-01-01T00:00:00Z").SetValue(&sc.limitMinTime)
+	cmd.Flag("max-matched-series", "Maximum number of series can be matched before reading series data").Default("0").IntVar(&sc.limitMaxMatchedSeries)
 }

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.1
 	// Prometheus maps version 2.x.y to tags v0.x.y.
 	github.com/prometheus/prometheus v0.39.1
-	github.com/rueian/rueidis v0.0.64
+	github.com/rueian/rueidis v0.0.69
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df
@@ -152,6 +152,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.1 // indirect
 	github.com/aws/smithy-go v1.11.1 // indirect
 	github.com/baidubce/bce-sdk-go v0.9.111 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/chromedp/sysutil v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.1
 	// Prometheus maps version 2.x.y to tags v0.x.y.
 	github.com/prometheus/prometheus v0.39.1
-	github.com/rueian/rueidis v0.0.69
+	github.com/rueian/rueidis v0.0.80
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	github.com/prometheus/exporter-toolkit v0.7.1
 	// Prometheus maps version 2.x.y to tags v0.x.y.
 	github.com/prometheus/prometheus v0.39.1
+	github.com/rueian/rueidis v0.0.64
 	github.com/sony/gobreaker v0.5.0
 	github.com/stretchr/testify v1.8.0
 	github.com/thanos-community/promql-engine v0.0.0-20221004075442-da92170150df
@@ -265,6 +266,7 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
 	howett.net/plist v0.0.0-20181124034731-591f970eefbb // indirect
+
 )
 
 replace (

--- a/go.mod
+++ b/go.mod
@@ -257,6 +257,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
 	golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 // indirect
@@ -287,3 +288,5 @@ replace (
 	k8s.io/klog => github.com/simonpasquier/klog-gokit v0.3.0
 	k8s.io/klog/v2 => github.com/simonpasquier/klog-gokit/v3 v3.0.0
 )
+
+replace github.com/prometheus/prometheus => github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b

--- a/go.sum
+++ b/go.sum
@@ -889,8 +889,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rueian/rueidis v0.0.69 h1:F4tiDGuyPZq4Ia83hU6pBeZibS3CsZ7+8IJPiDSbdWk=
-github.com/rueian/rueidis v0.0.69/go.mod h1:FwnfDILF2GETrvXcYFlhIiru/7NmSIm1f+7C5kutO0I=
+github.com/rueian/rueidis v0.0.80 h1:HfhTWc4gk7dMWd9vl7EVE4NkgMGjYFsyyhi6B6JV+b4=
+github.com/rueian/rueidis v0.0.80/go.mod h1:LiKWMM/QnILwRfDZIhSIXi4vQqZ/UZy4+/aNkSCt8XA=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/go.sum
+++ b/go.sum
@@ -781,7 +781,7 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.18.1 h1:M1GfJqGRrBrrGGsbxzV5dqM2U2ApXefZCQpkukxYRLE=
+github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
@@ -890,6 +890,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rueian/rueidis v0.0.64 h1:arI7CDnpIDynl9kbxdtdKNmGGTjuQrz443/rqmBBriI=
+github.com/rueian/rueidis v0.0.64/go.mod h1:FwnfDILF2GETrvXcYFlhIiru/7NmSIm1f+7C5kutO0I=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/go.sum
+++ b/go.sum
@@ -680,7 +680,7 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20210210170715-a
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lightstep/lightstep-tracer-go v0.25.0 h1:sGVnz8h3jTQuHKMbUe2949nXm3Sg09N1UcR3VoQNN5E=
 github.com/lightstep/lightstep-tracer-go v0.25.0/go.mod h1:G1ZAEaqTHFPWpWunnbUn1ADEY/Jvzz7jIOaXwAfD6A8=
-github.com/linode/linodego v1.9.1 h1:29UpEPpYcGFnbwiJW8mbk/bjBZpgd/pv68io2IKTo34=
+github.com/linode/linodego v1.9.3 h1:+lxNZw4avRxhCqGjwfPgQ2PvMT+vOL0OMsTdzixR7hQ=
 github.com/lovoo/gcloud-opentracing v0.3.0 h1:nAeKG70rIsog0TelcEtt6KU0Y1s5qXtsDLnHp0urPLU=
 github.com/lovoo/gcloud-opentracing v0.3.0/go.mod h1:ZFqk2y38kMDDikZPAK7ynTTGuyt17nSPdS3K5e+ZTBY=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ81pIr0yLvtUWk2if982qA3F3QD6H4=
@@ -876,8 +876,6 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
-github.com/prometheus/prometheus v0.39.1 h1:abZM6A+sKAv2eKTbRIaHq4amM/nT07MuxRm0+QTaTj0=
-github.com/prometheus/prometheus v0.39.1/go.mod h1:GjQjgLhHMc0oo4Ko7qt/yBSJMY4hUoiAZwsYQgjaePA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -980,6 +978,8 @@ github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVK
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b h1:H0DX65Gffby6rnTCOPsVbJr7SPtm15iXlmcQamz4Lj0=
+github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b/go.mod h1:c+P8gk6s+I+yURJ6laXnNZUJOf0jwjN+CCiie4lGQuc=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/weaveworks/common v0.0.0-20220706100410-67d27ed40fae h1:Z8YibUpdBEdCq8nwrYXJQ8vYooevbmEBIdFpseXK3/8=
 github.com/weaveworks/common v0.0.0-20220706100410-67d27ed40fae/go.mod h1:YfOOLoW1Q/jIIu0WLeSwgStmrKjuJEZSKTAUc+0KFvE=
@@ -1124,6 +1124,7 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -1649,9 +1650,9 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb h1:jhnBjNi9UFpfpl8YZhA9CrOqpnJdvzuiHsl/dnxl11M=
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
-k8s.io/api v0.25.1 h1:yL7du50yc93k17nH/Xe9jujAYrcDkI/i5DL1jPz4E3M=
-k8s.io/apimachinery v0.25.1 h1:t0XrnmCEHVgJlR2arwO8Awp9ylluDic706WePaYCBTI=
-k8s.io/client-go v0.25.1 h1:uFj4AJKtE1/ckcSKz8IhgAuZTdRXZDKev8g387ndD58=
+k8s.io/api v0.25.2 h1:v6G8RyFcwf0HR5jQGIAYlvtRNrxMJQG1xJzaSeVnIS8=
+k8s.io/apimachinery v0.25.2 h1:WbxfAjCx+AeN8Ilp9joWnyJ6xu9OMeS/fsfjK/5zaQs=
+k8s.io/client-go v0.25.2 h1:SUPp9p5CwM0yXGQrwYurw9LWz+YtMwhWd0GqOsSiefo=
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkIFQtZShWqoha7snGixVgEA=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,9 @@ github.com/aws/smithy-go v1.11.1/go.mod h1:3xHYmszWVx2c0kIwQeEVf9uSm4fYZt67FBJnw
 github.com/baidubce/bce-sdk-go v0.9.111 h1:yGgtPpZYUZW4uoVorQ4xnuEgVeddACydlcJKW87MDV4=
 github.com/baidubce/bce-sdk-go v0.9.111/go.mod h1:zbYJMQwE4IZuyrJiFO8tO8NbtYiKTFTbwh4eIsqjVdg=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f h1:ZNv7On9kyUzm7fvRZumSyy/IUiSC7AzL0I1jKKtwooA=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -890,8 +891,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
-github.com/rueian/rueidis v0.0.64 h1:arI7CDnpIDynl9kbxdtdKNmGGTjuQrz443/rqmBBriI=
-github.com/rueian/rueidis v0.0.64/go.mod h1:FwnfDILF2GETrvXcYFlhIiru/7NmSIm1f+7C5kutO0I=
+github.com/rueian/rueidis v0.0.69 h1:F4tiDGuyPZq4Ia83hU6pBeZibS3CsZ7+8IJPiDSbdWk=
+github.com/rueian/rueidis v0.0.69/go.mod h1:FwnfDILF2GETrvXcYFlhIiru/7NmSIm1f+7C5kutO0I=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=

--- a/pkg/cache/rueidis.go
+++ b/pkg/cache/rueidis.go
@@ -1,0 +1,69 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package cache
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/thanos-io/thanos/pkg/cacheutil"
+)
+
+// RueidisCache is a redis cache.
+type RueidisCache struct {
+	logger      log.Logger
+	redisClient *cacheutil.RueidisClient
+	name        string
+
+	// Metrics.
+	requests prometheus.Counter
+	hits     prometheus.Counter
+}
+
+// NewRueidisCache makes a new RueidisCache.
+func NewRueidisCache(name string, logger log.Logger, redisClient *cacheutil.RueidisClient, reg prometheus.Registerer) *RueidisCache {
+	c := &RueidisCache{
+		logger:      logger,
+		redisClient: redisClient,
+		name:        name,
+	}
+
+	c.requests = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name:        "thanos_cache_redis_requests_total",
+		Help:        "Total number of items requests to redis.",
+		ConstLabels: prometheus.Labels{"name": name},
+	})
+
+	c.hits = promauto.With(reg).NewCounter(prometheus.CounterOpts{
+		Name:        "thanos_cache_redis_hits_total",
+		Help:        "Total number of items requests to the cache that were a hit.",
+		ConstLabels: prometheus.Labels{"name": name},
+	})
+
+	level.Info(logger).Log("msg", "created redis cache")
+
+	return c
+}
+
+// Store data identified by keys.
+func (c *RueidisCache) Store(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	c.redisClient.SetMulti(ctx, data, ttl)
+}
+
+// Fetch fetches multiple keys and returns a map containing cache hits, along with a list of missing keys.
+// In case of error, it logs and return an empty cache hits map.
+func (c *RueidisCache) Fetch(ctx context.Context, keys []string) map[string][]byte {
+	c.requests.Add(float64(len(keys)))
+	results := c.redisClient.GetMulti(ctx, keys)
+	c.hits.Add(float64(len(results)))
+	return results
+}
+
+func (c *RueidisCache) Name() string {
+	return c.name
+}

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -124,7 +124,7 @@ type RedisClientConfig struct {
 }
 
 func (c *RedisClientConfig) validate() error {
-	if c.Addr == "" {
+	if c.Addr == "" && len(c.Addrs) == 0 {
 		return errors.New("no redis addr provided")
 	}
 

--- a/pkg/cacheutil/redis_client.go
+++ b/pkg/cacheutil/redis_client.go
@@ -60,6 +60,8 @@ type RedisClientConfig struct {
 	// Addr specifies the addresses of redis server.
 	Addr string `yaml:"addr"`
 
+	Addrs []string `yaml:"addrs"`
+
 	// Use the specified Username to authenticate the current connection
 	// with one of the connections defined in the ACL list when connecting
 	// to a Redis 6.0 instance, or greater, that is using the Redis ACL system.
@@ -72,6 +74,8 @@ type RedisClientConfig struct {
 
 	// DB Database to be selected after connecting to the server.
 	DB int `yaml:"db"`
+
+	CacheSize int `yaml:"cachesize"`
 
 	// DialTimeout specifies the client dial timeout.
 	DialTimeout time.Duration `yaml:"dial_timeout"`

--- a/pkg/cacheutil/rueidis_client.go
+++ b/pkg/cacheutil/rueidis_client.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package cacheutil
 
 import (

--- a/pkg/cacheutil/rueidis_client.go
+++ b/pkg/cacheutil/rueidis_client.go
@@ -1,0 +1,148 @@
+package cacheutil
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/rueian/rueidis"
+)
+
+// RueidisClient is a wrap of rueidis.Client.
+type RueidisClient struct {
+	client rueidis.Client
+	config RedisClientConfig
+
+	logger           log.Logger
+	durationSet      prometheus.Observer
+	durationSetMulti prometheus.Observer
+	durationGetMulti prometheus.Observer
+}
+
+// NewRueidisClient makes a new RueidisClient.
+func NewRueidisClient(logger log.Logger, name string, conf []byte, reg prometheus.Registerer) (*RueidisClient, error) {
+	config, err := parseRedisClientConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewRueidisClientWithConfig(logger, name, config, reg)
+}
+
+// NewRueidisClientWithConfig makes a new RedisClient.
+func NewRueidisClientWithConfig(logger log.Logger, name string, config RedisClientConfig,
+	reg prometheus.Registerer) (*RueidisClient, error) {
+
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+	var addrs []string
+
+	if len(config.Addrs) > 0 {
+		addrs = config.Addrs
+	} else {
+		addrs = []string{config.Addr}
+	}
+
+	var cacheSize int
+
+	if config.CacheSize != 0 {
+		cacheSize = config.CacheSize
+	} else {
+		cacheSize = 1024 * (1 << 20)
+	}
+
+	client, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:       addrs,
+		ShuffleInit:       true,
+		Username:          config.Username,
+		Password:          config.Password,
+		SelectDB:          config.DB,
+		CacheSizeEachConn: cacheSize,
+		Dialer:            net.Dialer{Timeout: config.DialTimeout},
+		ConnWriteTimeout:  config.WriteTimeout,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if reg != nil {
+		reg = prometheus.WrapRegistererWith(prometheus.Labels{"name": name}, reg)
+	}
+
+	c := &RueidisClient{
+		client: client,
+		config: config,
+		logger: logger,
+	}
+	duration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "thanos_redis_operation_duration_seconds",
+		Help:    "Duration of operations against redis.",
+		Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1, 3, 6, 10},
+	}, []string{"operation"})
+	c.durationSet = duration.WithLabelValues(opSet)
+	c.durationSetMulti = duration.WithLabelValues(opSetMulti)
+	c.durationGetMulti = duration.WithLabelValues(opGetMulti)
+	return c, nil
+}
+
+// SetAsync implement RemoteCacheClient.
+func (c *RueidisClient) SetAsync(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	start := time.Now()
+	if err := c.client.Do(ctx, c.client.B().Set().Key(key).Value(rueidis.BinaryString(value)).ExSeconds(int64(ttl.Seconds())).Build()).Error(); err != nil {
+		level.Warn(c.logger).Log("msg", "failed to set item into redis", "err", err, "key", key, "value_size", len(value))
+		return nil
+	}
+	c.durationSet.Observe(time.Since(start).Seconds())
+	return nil
+}
+
+// SetMulti set multiple keys and value.
+func (c *RueidisClient) SetMulti(ctx context.Context, data map[string][]byte, ttl time.Duration) {
+	if len(data) == 0 {
+		return
+	}
+	start := time.Now()
+	sets := make(rueidis.Commands, 0, len(data))
+	ittl := int64(ttl.Seconds())
+	for k, v := range data {
+		sets = append(sets, c.client.B().Setex().Key(k).Seconds(ittl).Value(rueidis.BinaryString(v)).Build())
+	}
+	for _, resp := range c.client.DoMulti(ctx, sets...) {
+		if err := resp.Error(); err != nil {
+			level.Warn(c.logger).Log("msg", "failed to set multi items from redis", "err", err, "items", len(data))
+			return
+		}
+	}
+	c.durationSetMulti.Observe(time.Since(start).Seconds())
+}
+
+// GetMulti implement RemoteCacheClient.
+func (c *RueidisClient) GetMulti(ctx context.Context, keys []string) map[string][]byte {
+	if len(keys) == 0 {
+		return nil
+	}
+	start := time.Now()
+	results := make(map[string][]byte, len(keys))
+
+	resps, err := c.client.DoCache(ctx, c.client.B().Mget().Key(keys...).Cache(), 8*time.Hour).ToArray()
+	if err != nil {
+		level.Warn(c.logger).Log("msg", "failed to mget items from redis", "err", err, "items", len(resps))
+	}
+	for i, resp := range resps {
+		if val, err := resp.ToString(); err == nil {
+			results[keys[i]] = stringToBytes(val)
+		}
+	}
+	c.durationGetMulti.Observe(time.Since(start).Seconds())
+	return results
+}
+
+// Stop implement RemoteCacheClient.
+func (c *RueidisClient) Stop() {
+	c.client.Close()
+}

--- a/pkg/promclient/promclient.go
+++ b/pkg/promclient/promclient.go
@@ -840,3 +840,33 @@ func (c *Client) TargetsInGRPC(ctx context.Context, base *url.URL, stateTargets 
 	}
 	return v.Data, c.get2xxResultWithGRPCErrors(ctx, "/prom_targets HTTP[client]", &u, &v)
 }
+
+func (c *Client) SeriesMatchCount(ctx context.Context, base *url.URL, matchers []*labels.Matcher, start, end int64) (int, error) {
+	u := *base
+	u.Path = path.Join(u.Path, "/api/v1/series")
+	q := u.Query()
+
+	q.Add("match[]", storepb.PromMatchersToString(matchers...))
+	q.Add("start", formatTime(timestamp.Time(start)))
+	q.Add("end", formatTime(timestamp.Time(end)))
+	q.Add("only_count", "1")
+	u.RawQuery = q.Encode()
+
+	body, _, err := c.req2xx(ctx, &u, http.MethodGet)
+	if err != nil {
+		return -1, errors.Wrap(err, "read query instant response")
+	}
+
+	var m struct {
+		Status string `json:"status"`
+		Data   struct {
+			MetricsCount int `json:"metrics_count"`
+		} `json:"data"`
+	}
+
+	if err = json.Unmarshal(body, &m); err != nil {
+		return -1, errors.Wrap(err, "unmarshal query instant response")
+	}
+
+	return m.Data.MetricsCount, nil
+}

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -210,7 +210,7 @@ func newBucketStoreMetrics(reg prometheus.Registerer) *bucketStoreMetrics {
 		Name: "thanos_bucket_store_postings_size_bytes",
 		Help: "Size in bytes of the postings for a single series call.",
 		Buckets: []float64{
-			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024,
+			32, 256, 512, 1024, 32 * 1024, 256 * 1024, 512 * 1024, 1024 * 1024, 32 * 1024 * 1024, 256 * 1024 * 1024, 512 * 1024 * 1024, 768 * 1024 * 1024, 1024 * 1024 * 1024, 1536 * 1024 * 1024, 2048 * 1024 * 1024, 2560 * 1024 * 1024, 3072 * 1024 * 1024, 4096 * 1024 * 1024,
 		},
 	})
 

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -89,7 +89,7 @@ const (
 	// not too small (too much memory).
 	DefaultPostingOffsetInMemorySampling = 32
 
-	PartitionerMaxGapSize = 512 * 1024
+	PartitionerMaxGapSize = 128 * 1024
 
 	// Labels for metrics.
 	labelEncode = "encode"
@@ -2701,6 +2701,7 @@ func (r *bucketChunkReader) loadChunks(ctx context.Context, res []seriesEntry, a
 
 		r.block.chunkPool.Put(nb)
 	}
+
 	return nil
 }
 

--- a/pkg/store/cache/caching_bucket_factory.go
+++ b/pkg/store/cache/caching_bucket_factory.go
@@ -119,7 +119,12 @@ func NewCachingBucketFromYaml(yamlContent []byte, bucket objstore.Bucket, logger
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create groupcache")
 		}
-
+	case string(RUEIDIS):
+		rueidis, err := cacheutil.NewRueidisClient(logger, "caching-cache", backendConfig, reg)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create redis client")
+		}
+		c = cache.NewRueidisCache("caching-bucket", logger, rueidis, reg)
 	case string(RedisBucketCacheProvider):
 		redisCache, err := cacheutil.NewRedisClient(logger, "caching-bucket", backendConfig, reg)
 		if err != nil {

--- a/pkg/store/cache/factory.go
+++ b/pkg/store/cache/factory.go
@@ -22,6 +22,7 @@ const (
 	INMEMORY  IndexCacheProvider = "IN-MEMORY"
 	MEMCACHED IndexCacheProvider = "MEMCACHED"
 	REDIS     IndexCacheProvider = "REDIS"
+	RUEIDIS   IndexCacheProvider = "RUEIDIS"
 )
 
 // IndexCacheConfig specifies the index cache config.
@@ -52,6 +53,13 @@ func NewIndexCache(logger log.Logger, confContentYaml []byte, reg prometheus.Reg
 		memcached, err = cacheutil.NewMemcachedClient(logger, "index-cache", backendConfig, reg)
 		if err == nil {
 			cache, err = NewRemoteIndexCache(logger, memcached, reg)
+		}
+	case string(RUEIDIS):
+		var rueidis cacheutil.RemoteCacheClient
+
+		rueidis, err = cacheutil.NewRueidisClient(logger, "index-cache", backendConfig, reg)
+		if err == nil {
+			cache, err = NewRemoteIndexCache(logger, rueidis, reg)
 		}
 	case string(REDIS):
 		var redisCache cacheutil.RemoteCacheClient

--- a/pkg/store/prometheus.go
+++ b/pkg/store/prometheus.go
@@ -139,6 +139,10 @@ func (p *PrometheusStore) putBuffer(b *[]byte) {
 	p.buffers.Put(b)
 }
 
+type timerange struct {
+	mintime, maxtime int64
+}
+
 // Series returns all series for a requested time range and label matcher.
 func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_SeriesServer) error {
 	extLset := p.externalLabelsFn()
@@ -201,29 +205,46 @@ func (p *PrometheusStore) Series(r *storepb.SeriesRequest, s storepb.Store_Serie
 		return p.queryPrometheus(s, r)
 	}
 
-	q := &prompb.Query{StartTimestampMs: r.MinTime, EndTimestampMs: r.MaxTime}
-	for _, m := range matchers {
-		pm := &prompb.LabelMatcher{Name: m.Name, Value: m.Value}
-
-		switch m.Type {
-		case labels.MatchEqual:
-			pm.Type = prompb.LabelMatcher_EQ
-		case labels.MatchNotEqual:
-			pm.Type = prompb.LabelMatcher_NEQ
-		case labels.MatchRegexp:
-			pm.Type = prompb.LabelMatcher_RE
-		case labels.MatchNotRegexp:
-			pm.Type = prompb.LabelMatcher_NRE
-		default:
-			return errors.New("unrecognized matcher type")
+	timeranges := []timerange{}
+	if r.QueryHints != nil {
+		if r.QueryHints.Range.Millis != 0 && r.QueryHints.Range.Millis*4 < r.QueryHints.StepMillis {
+			for ts := r.MinTime; ts <= r.MaxTime; ts += r.QueryHints.StepMillis {
+				timeranges = append(timeranges, timerange{ts, ts + r.QueryHints.Range.Millis})
+			}
 		}
-		q.Matchers = append(q.Matchers, pm)
+	}
+
+	if len(timeranges) == 0 {
+		timeranges = []timerange{{r.MinTime, r.MaxTime}}
+	}
+
+	queries := []*prompb.Query{}
+	for _, tr := range timeranges {
+		q := &prompb.Query{StartTimestampMs: tr.mintime, EndTimestampMs: tr.maxtime}
+		for _, m := range matchers {
+			pm := &prompb.LabelMatcher{Name: m.Name, Value: m.Value}
+
+			switch m.Type {
+			case labels.MatchEqual:
+				pm.Type = prompb.LabelMatcher_EQ
+			case labels.MatchNotEqual:
+				pm.Type = prompb.LabelMatcher_NEQ
+			case labels.MatchRegexp:
+				pm.Type = prompb.LabelMatcher_RE
+			case labels.MatchNotRegexp:
+				pm.Type = prompb.LabelMatcher_NRE
+			default:
+				return errors.New("unrecognized matcher type")
+			}
+			q.Matchers = append(q.Matchers, pm)
+		}
+		queries = append(queries, q)
 	}
 
 	queryPrometheusSpan, ctx := tracing.StartSpan(s.Context(), "query_prometheus")
-	queryPrometheusSpan.SetTag("query.request", q.String())
+	queryPrometheusSpan.SetTag("query.request", queries[0].String())
 
-	httpResp, err := p.startPromRemoteRead(ctx, q)
+	httpResp, err := p.startPromRemoteRead(ctx, queries)
 	if err != nil {
 		queryPrometheusSpan.Finish()
 		return errors.Wrap(err, "query Prometheus")
@@ -320,36 +341,42 @@ func (p *PrometheusStore) handleSampledPrometheusResponse(s storepb.Store_Series
 
 	span, _ := tracing.StartSpan(s.Context(), "transform_and_respond")
 	defer span.Finish()
-	span.SetTag("series_count", len(resp.Results[0].Timeseries))
+	seriesCount := 0
 
-	for _, e := range resp.Results[0].Timeseries {
-		lset := labelpb.ExtendSortedLabels(labelpb.ZLabelsToPromLabels(e.Labels), extLset)
-		if len(e.Samples) == 0 {
-			// As found in https://github.com/thanos-io/thanos/issues/381
-			// Prometheus can give us completely empty time series. Ignore these with log until we figure out that
-			// this is expected from Prometheus perspective.
-			level.Warn(p.logger).Log(
-				"msg",
-				"found timeseries without any chunk. See https://github.com/thanos-io/thanos/issues/381 for details",
-				"lset",
-				fmt.Sprintf("%v", lset),
-			)
-			continue
-		}
+	for _, r := range resp.Results {
+		for _, e := range r.Timeseries {
+			seriesCount++
+			lset := labelpb.ExtendSortedLabels(labelpb.ZLabelsToPromLabels(e.Labels), extLset)
+			if len(e.Samples) == 0 {
+				// As found in https://github.com/thanos-io/thanos/issues/381
+				// Prometheus can give us completely empty time series. Ignore these with log until we figure out that
+				// this is expected from Prometheus perspective.
+				level.Warn(p.logger).Log(
+					"msg",
+					"found timeseries without any chunk. See https://github.com/thanos-io/thanos/issues/381 for details",
+					"lset",
+					fmt.Sprintf("%v", lset),
+				)
+				continue
+			}
 
-		aggregatedChunks, err := p.chunkSamples(e, MaxSamplesPerChunk)
-		if err != nil {
-			return err
-		}
+			aggregatedChunks, err := p.chunkSamples(e, MaxSamplesPerChunk)
+			if err != nil {
+				return err
+			}
 
-		if err := s.Send(storepb.NewSeriesResponse(&storepb.Series{
-			Labels: labelpb.ZLabelsFromPromLabels(lset),
-			Chunks: aggregatedChunks,
-		})); err != nil {
-			return err
+			if err := s.Send(storepb.NewSeriesResponse(&storepb.Series{
+				Labels: labelpb.ZLabelsFromPromLabels(lset),
+				Chunks: aggregatedChunks,
+			})); err != nil {
+				return err
+			}
 		}
 	}
-	level.Debug(p.logger).Log("msg", "handled ReadRequest_SAMPLED request.", "series", len(resp.Results[0].Timeseries))
+
+	span.SetTag("series_count", seriesCount)
+
+	level.Debug(p.logger).Log("msg", "handled ReadRequest_SAMPLED request.", "series", seriesCount)
 	return nil
 }
 
@@ -521,9 +548,9 @@ func (p *PrometheusStore) chunkSamples(series *prompb.TimeSeries, maxSamplesPerC
 	return chks, nil
 }
 
-func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, q *prompb.Query) (presp *http.Response, err error) {
+func (p *PrometheusStore) startPromRemoteRead(ctx context.Context, queries []*prompb.Query) (presp *http.Response, err error) {
 	reqb, err := proto.Marshal(&prompb.ReadRequest{
-		Queries:               []*prompb.Query{q},
+		Queries:               queries,
 		AcceptedResponseTypes: p.remoteReadAcceptableResponses,
 	})
 	if err != nil {

--- a/pkg/store/prometheus_test.go
+++ b/pkg/store/prometheus_test.go
@@ -64,7 +64,7 @@ func testPrometheusStoreSeriesE2e(t *testing.T, prefix string) {
 	limitMinT := int64(0)
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return limitMinT, -1 }, nil) // Maxt does not matter.
+		func() (int64, int64) { return limitMinT, -1 }, nil, 0) // Maxt does not matter.
 	testutil.Ok(t, err)
 
 	// Query all three samples except for the first one. Since we round up queried data
@@ -191,7 +191,7 @@ func TestPrometheusStore_SeriesLabels_e2e(t *testing.T) {
 
 	promStore, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 }, nil)
+		func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 }, nil, 0)
 	testutil.Ok(t, err)
 
 	for _, tcase := range []struct {
@@ -361,7 +361,7 @@ func TestPrometheusStore_LabelAPIs(t *testing.T) {
 
 		promStore, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar, func() labels.Labels {
 			return extLset
-		}, nil, func() string { return version })
+		}, nil, func() string { return version }, 0)
 		testutil.Ok(t, err)
 
 		return promStore
@@ -396,7 +396,7 @@ func TestPrometheusStore_Series_MatchExternalLabel(t *testing.T) {
 
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return 0, math.MaxInt64 }, nil)
+		func() (int64, int64) { return 0, math.MaxInt64 }, nil, 0)
 	testutil.Ok(t, err)
 	srv := newStoreSeriesServer(ctx)
 
@@ -430,6 +430,99 @@ func TestPrometheusStore_Series_MatchExternalLabel(t *testing.T) {
 	testutil.Equals(t, 0, len(srv.SeriesSet))
 }
 
+func TestPrometheusStore_Series_LimitMaxMatchedSeries(t *testing.T) {
+	defer testutil.TolerantVerifyLeak(t)
+
+	p, err := e2eutil.NewPrometheus()
+	testutil.Ok(t, err)
+	defer func() { testutil.Ok(t, p.Stop()) }()
+
+	baseT := timestamp.FromTime(time.Now()) / 1000 * 1000
+
+	a := p.Appender()
+	_, err = a.Append(0, labels.FromStrings("a", "b", "b", "d"), baseT+100, 1)
+	testutil.Ok(t, err)
+	_, err = a.Append(0, labels.FromStrings("a", "c", "b", "d", "job", "test"), baseT+200, 2)
+	testutil.Ok(t, err)
+	_, err = a.Append(0, labels.FromStrings("a", "d", "b", "d", "job", "test"), baseT+300, 3)
+	testutil.Ok(t, err)
+	_, err = a.Append(0, labels.FromStrings("b", "d", "job", "test"), baseT+400, 4)
+	testutil.Ok(t, err)
+	testutil.Ok(t, a.Commit())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testutil.Ok(t, p.Start())
+
+	u, err := url.Parse(fmt.Sprintf("http://%s", p.Addr()))
+	testutil.Ok(t, err)
+
+	req := &storepb.SeriesRequest{
+		SkipChunks: true,
+		Matchers: []storepb.LabelMatcher{
+			{Type: storepb.LabelMatcher_EQ, Name: "job", Value: "test"},
+		},
+		MinTime: baseT,
+		MaxTime: baseT + 300,
+	}
+
+	expected2Series := []storepb.Series{
+		{
+			Labels: []labelpb.ZLabel{{Name: "a", Value: "c"}, {Name: "b", Value: "d"}, {Name: "job", Value: "test"}, {Name: "region", Value: "eu-west"}},
+		},
+		{
+			Labels: []labelpb.ZLabel{{Name: "a", Value: "d"}, {Name: "b", Value: "d"}, {Name: "job", Value: "test"}, {Name: "region", Value: "eu-west"}},
+		},
+	}
+
+	for _, tcase := range []struct {
+		req                   *storepb.SeriesRequest
+		expected              []storepb.Series
+		expectedErr           error
+		limitMaxMatchedSeries int
+	}{
+		// limit is not active
+		{
+			limitMaxMatchedSeries: 0,
+			req:                   req,
+			expected:              expected2Series,
+		},
+		// should return limit error as 'limit < matched series'
+		{
+			limitMaxMatchedSeries: 1,
+			req:                   req,
+			expected:              expected2Series,
+			expectedErr:           ErrSeriesMatchLimitReached,
+		},
+		// should succeed as limit is not reached
+		{
+			limitMaxMatchedSeries: 2,
+			req:                   req,
+			expected:              expected2Series,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			promStore, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
+				func() labels.Labels { return labels.FromStrings("region", "eu-west") },
+				func() (int64, int64) { return math.MinInt64/1000 + 62135596801, math.MaxInt64/1000 - 62135596801 }, nil,
+				tcase.limitMaxMatchedSeries)
+			testutil.Ok(t, err)
+
+			srv := newStoreSeriesServer(ctx)
+			err = promStore.Series(tcase.req, srv)
+			if tcase.expectedErr != nil {
+				testutil.NotOk(t, err)
+				testutil.Equals(t, tcase.expectedErr.Error(), err.Error())
+				return
+			}
+			testutil.Ok(t, err)
+			testutil.Equals(t, []string(nil), srv.Warnings)
+			testutil.Equals(t, tcase.expected, srv.SeriesSet)
+		})
+	}
+}
+
 func TestPrometheusStore_Info(t *testing.T) {
 	defer testutil.TolerantVerifyLeak(t)
 
@@ -438,7 +531,7 @@ func TestPrometheusStore_Info(t *testing.T) {
 
 	proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), nil, component.Sidecar,
 		func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-		func() (int64, int64) { return 123, 456 }, nil)
+		func() (int64, int64) { return 123, 456 }, nil, 0)
 	testutil.Ok(t, err)
 
 	resp, err := proxy.Info(ctx, &storepb.InfoRequest{})
@@ -516,7 +609,7 @@ func TestPrometheusStore_Series_SplitSamplesIntoChunksWithMaxSizeOf120(t *testin
 
 		proxy, err := NewPrometheusStore(nil, nil, promclient.NewDefaultClient(), u, component.Sidecar,
 			func() labels.Labels { return labels.FromStrings("region", "eu-west") },
-			func() (int64, int64) { return 0, math.MaxInt64 }, nil)
+			func() (int64, int64) { return 0, math.MaxInt64 }, nil, 0)
 		testutil.Ok(t, err)
 
 		// We build chunks only for SAMPLES method. Make sure we ask for SAMPLES only.


### PR DESCRIPTION
Port patches and remove irrelevant ones:

* Add Rueidis client to index/caching bucket
* Update promql-engine to one with fork && Select() caching
* Optimize data retrieval
* Reduced Thanos Store gap
* Added metrics for postings fetched/touched
* Sidecar series limit