### PR TITLE
go.mod: update promql-engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -291,4 +291,4 @@ replace (
 
 replace github.com/prometheus/prometheus => github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b
 
-replace github.com/thanos-community/promql-engine => github.com/vinted/promql-engine v0.0.0-20221024105757-4c9896d26166
+replace github.com/thanos-community/promql-engine => github.com/vinted/promql-engine v0.0.0-20221025073014-4342fbdbce58

--- a/go.sum
+++ b/go.sum
@@ -978,8 +978,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b h1:H0DX65Gffby6rnTCOPsVbJr7SPtm15iXlmcQamz4Lj0=
 github.com/vinted/prometheus v1.8.2-0.20221017101217-e895ef3dbe4b/go.mod h1:c+P8gk6s+I+yURJ6laXnNZUJOf0jwjN+CCiie4lGQuc=
-github.com/vinted/promql-engine v0.0.0-20221024105757-4c9896d26166 h1:IzF7at6R33C7gz/8TM5clYWsUqr93qBL7ocyj6kJ40A=
-github.com/vinted/promql-engine v0.0.0-20221024105757-4c9896d26166/go.mod h1:yHSkMOTkwTMqy/Txr7ubTEq3f7UwduwQ8OvvNhfq1Z4=
+github.com/vinted/promql-engine v0.0.0-20221025073014-4342fbdbce58 h1:mIsyHos3lOqY2mH4+uOsUnqbIOaIHfF2DKqAoUbYcEs=
+github.com/vinted/promql-engine v0.0.0-20221025073014-4342fbdbce58/go.mod h1:REz4kWZKoCMIlcdisdfXnH1jCZRCnAVc571wfDORKGE=
 github.com/vultr/govultr/v2 v2.17.2 h1:gej/rwr91Puc/tgh+j33p/BLR16UrIPnSr+AIwYWZQs=
 github.com/weaveworks/common v0.0.0-20220706100410-67d27ed40fae h1:Z8YibUpdBEdCq8nwrYXJQ8vYooevbmEBIdFpseXK3/8=
 github.com/weaveworks/common v0.0.0-20220706100410-67d27ed40fae/go.mod h1:YfOOLoW1Q/jIIu0WLeSwgStmrKjuJEZSKTAUc+0KFvE=


### PR DESCRIPTION
Fixes goroutine
leak. https://github.com/thanos-community/promql-engine/commit/52d728e59fa0b21d05230196d4b366f4837d0a41
