### PR TITLE
query: rework to use gate pkg

### DIFF
--- a/pkg/query/querier.go
+++ b/pkg/query/querier.go
@@ -16,11 +16,9 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
-	promgate "github.com/prometheus/prometheus/util/gate"
 
 	"github.com/thanos-io/thanos/pkg/dedup"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -71,10 +69,6 @@ func NewQueryableCreator(
 	maxConcurrentSelects int,
 	selectTimeout time.Duration,
 ) QueryableCreator {
-	duration := promauto.With(
-		extprom.WrapRegistererWithPrefix("concurrent_selects_", reg),
-	).NewHistogram(gate.DurationHistogramOpts)
-
 	return func(
 		deduplicate bool,
 		replicaLabels []string,
@@ -96,7 +90,7 @@ func NewQueryableCreator(
 			partialResponse:     partialResponse,
 			skipChunks:          skipChunks,
 			gateProviderFn: func() gate.Gate {
-				return gate.InstrumentGateDuration(duration, promgate.New(maxConcurrentSelects))
+				return gate.New(extprom.WrapRegistererWithPrefix("concurrent_selects_", reg), maxConcurrentSelects)
 			},
 			maxConcurrentSelects: maxConcurrentSelects,
 			selectTimeout:        selectTimeout,


### PR DESCRIPTION
Use our own gate package which allows disabling max concurrent Select() calls. It uses the same promgate under the hood so there's no real functional change.

Signed-off-by: Giedrius Statkevičius <giedrius.statkevicius@vinted.com>
