### PR TITLE
querier: ensure decompression finishes

### DIFF
--- a/pkg/api/query/v1_test.go
+++ b/pkg/api/query/v1_test.go
@@ -189,7 +189,7 @@ func TestQueryEndpoints(t *testing.T) {
 		baseAPI: &baseAPI.BaseAPI{
 			Now: func() time.Time { return now },
 		},
-		queryableCreate:       query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
+		queryableCreate:       query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout, 0),
 		queryEngine:           qe,
 		lookbackDeltaCreate:   func(m int64) time.Duration { return time.Duration(0) },
 		gate:                  gate.New(nil, 4),
@@ -730,7 +730,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		baseAPI: &baseAPI.BaseAPI{
 			Now: func() time.Time { return now },
 		},
-		queryableCreate:     query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
+		queryableCreate:     query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout, 0),
 		queryEngine:         qe,
 		lookbackDeltaCreate: func(m int64) time.Duration { return time.Duration(0) },
 		gate:                gate.New(nil, 4),
@@ -743,7 +743,7 @@ func TestMetadataEndpoints(t *testing.T) {
 		baseAPI: &baseAPI.BaseAPI{
 			Now: func() time.Time { return now },
 		},
-		queryableCreate:          query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout),
+		queryableCreate:          query.NewQueryableCreator(nil, nil, store.NewTSDBStore(nil, db, component.Query, nil), 2, timeout, 0),
 		queryEngine:              qe,
 		lookbackDeltaCreate:      func(m int64) time.Duration { return time.Duration(0) },
 		gate:                     gate.New(nil, 4),

--- a/pkg/query/querier_test.go
+++ b/pkg/query/querier_test.go
@@ -41,7 +41,7 @@ type sample struct {
 
 func TestQueryableCreator_MaxResolution(t *testing.T) {
 	testProxy := &testStoreServer{resps: []*storepb.SeriesResponse{}}
-	queryableCreator := NewQueryableCreator(nil, nil, testProxy, 2, 5*time.Second)
+	queryableCreator := NewQueryableCreator(nil, nil, testProxy, 2, 5*time.Second, 0)
 
 	oneHourMillis := int64(1*time.Hour) / int64(time.Millisecond)
 	queryable := queryableCreator(
@@ -87,6 +87,7 @@ func TestQuerier_DownsampledData(t *testing.T) {
 		testProxy,
 		2,
 		timeout,
+		0,
 	)(false,
 		nil,
 		nil,
@@ -390,7 +391,7 @@ func TestQuerier_Select_AfterPromQL(t *testing.T) {
 						g := gate.New(2)
 						mq := &mockedQueryable{
 							Creator: func(mint, maxt int64) storage.Querier {
-								return newQuerier(context.Background(), nil, mint, maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter)
+								return newQuerier(context.Background(), nil, mint, maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter, 0)
 							},
 						}
 						t.Cleanup(func() {
@@ -634,7 +635,7 @@ func TestQuerier_Select(t *testing.T) {
 				{dedup: true, expected: []series{tcase.expectedAfterDedup}},
 			} {
 				g := gate.New(2)
-				q := newQuerier(context.Background(), nil, tcase.mint, tcase.maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, false, g, timeout, nil, func(i storepb.SeriesStatsCounter) {})
+				q := newQuerier(context.Background(), nil, tcase.mint, tcase.maxt, tcase.replicaLabels, nil, tcase.storeAPI, sc.dedup, 0, true, false, false, g, timeout, nil, func(i storepb.SeriesStatsCounter) {}, 0)
 				t.Cleanup(func() { testutil.Ok(t, q.Close()) })
 
 				t.Run(fmt.Sprintf("dedup=%v", sc.dedup), func(t *testing.T) {
@@ -863,7 +864,7 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 
 		timeout := 100 * time.Second
 		g := gate.New(2)
-		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, false, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter)
+		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, false, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter, 0)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})
@@ -933,7 +934,7 @@ func TestQuerierWithDedupUnderstoodByPromQL_Rate(t *testing.T) {
 
 		timeout := 5 * time.Second
 		g := gate.New(2)
-		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, true, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter)
+		q := newQuerier(context.Background(), logger, realSeriesWithStaleMarkerMint, realSeriesWithStaleMarkerMaxt, []string{"replica"}, nil, s, true, 0, true, false, false, g, timeout, nil, NoopSeriesStatsReporter, 0)
 		t.Cleanup(func() {
 			testutil.Ok(t, q.Close())
 		})
@@ -1113,4 +1114,28 @@ func storeSeriesResponse(t testing.TB, lset labels.Labels, smplChunks ...[]sampl
 		s.Chunks = append(s.Chunks, ch)
 	}
 	return storepb.NewSeriesResponse(&s)
+}
+
+func TestDecompressHandlesErrorsProperly(t *testing.T) {
+	ss := &seriesServer{
+		symbolTables: []map[uint64]string{
+			{
+				0: "foo",
+			},
+		},
+	}
+
+	for i := 0; i < 1_000_000; i++ {
+		ss.compressedSeriesSet = append(ss.compressedSeriesSet, storepb.CompressedSeries{
+			Labels: []labelpb.CompressedLabel{
+				{
+					NameRef:  uint64(i),
+					ValueRef: uint64(i),
+				},
+			},
+			Chunks: []storepb.AggrChunk{},
+		})
+	}
+
+	testutil.NotOk(t, ss.DecompressSeries(context.Background(), 3))
 }

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -39,6 +39,7 @@ func TestQuerier_Proxy(t *testing.T) {
 				component.Debug, nil, 5*time.Minute, store.EagerRetrieval),
 			1000000,
 			5*time.Minute,
+			0,
 		)
 
 		createQueryableFn := func(stores []*testStore) storage.Queryable {


### PR DESCRIPTION
Ensure that decompress finishes eventually in case of errors. Add a test case to cover this. Also, add context.Context checking to cancel decompression early.
