### PR TITLE
errutil: fix deadlock

### DIFF
--- a/pkg/errutil/multierror.go
+++ b/pkg/errutil/multierror.go
@@ -47,7 +47,7 @@ func (es *SyncMultiError) Add(err error) {
 	es.mtx.Lock()
 	defer es.mtx.Unlock()
 
-	es.Add(err)
+	es.es.Add(err)
 }
 
 // Err returns the error list as an error or nil if it is empty.

--- a/pkg/errutil/multierror_test.go
+++ b/pkg/errutil/multierror_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package errutil
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMultiSyncErrorAdd(t *testing.T) {
+	sme := &SyncMultiError{}
+	sme.Add(fmt.Errorf("test"))
+}


### PR DESCRIPTION
Fix deadlock in the Add() function - it accidentally was calling itself recursively. This struct wraps a `MultiError` so we need to call `Add()` on that `MultiError` inside.

This deadlock can manifest in Receive - million+ leaking goroutines, all stuck on the MultiTSDB lock.
