### PR TITLE
receive/handler: fix label names/values race (#6825)

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -651,39 +651,54 @@ func (h *Handler) fanoutForward(pctx context.Context, tenant string, wreqs map[e
 		tLogger = log.With(h.logger, logTags)
 	}
 
-	responses := make(chan writeResponse)
+	// NOTE(GiedriusS): First write locally because inside of the function we check if the local TSDB has cached strings.
+	// If not then it copies those strings. This is so that the memory allocated for the
+	// protobuf (except for the labels) can be deallocated.
+	// This causes a write to the labels field. When fanning out this request to other Receivers, the code calls
+	// Size() which reads those same fields. We would like to avoid adding locks around each string
+	// hence we need to write locally first.
+	var maxBufferedResponses = 0
+	for writeTarget := range wreqs {
+		if writeTarget.endpoint != h.options.Endpoint {
+			continue
+		}
+		maxBufferedResponses++
+	}
+
+	responses := make(chan writeResponse, maxBufferedResponses)
 
 	var wg sync.WaitGroup
-	for writeTarget := range wreqs {
-		wg.Add(1)
 
+	for writeTarget := range wreqs {
+		if writeTarget.endpoint != h.options.Endpoint {
+			continue
+		}
 		// If the endpoint for the write request is the
 		// local node, then don't make a request but store locally.
 		// By handing replication to the local node in the same
 		// function as replication to other nodes, we can treat
 		// a failure to write locally as just another error that
 		// can be ignored if the replication factor is met.
-		if writeTarget.endpoint == h.options.Endpoint {
-			go func(writeTarget endpointReplica) {
-				defer wg.Done()
+		var err error
 
-				var err error
-				tracing.DoInSpan(fctx, "receive_tsdb_write", func(_ context.Context) {
-					err = h.writer.Write(fctx, tenant, &prompb.WriteRequest{
-						Timeseries: wreqs[writeTarget].timeSeries,
-					})
-				})
-				if err != nil {
-					level.Debug(tLogger).Log("msg", "local tsdb write failed", "err", err.Error())
-					responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, errors.Wrapf(err, "store locally for endpoint %v", writeTarget.endpoint))
-					return
-				}
-				responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, nil)
-			}(writeTarget)
-
+		tracing.DoInSpan(fctx, "receive_tsdb_write", func(_ context.Context) {
+			err = h.writer.Write(fctx, tenant, &prompb.WriteRequest{
+				Timeseries: wreqs[writeTarget].timeSeries,
+			})
+		})
+		if err != nil {
+			level.Debug(tLogger).Log("msg", "local tsdb write failed", "err", err.Error())
+			responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, errors.Wrapf(err, "store locally for endpoint %v", writeTarget.endpoint))
 			continue
 		}
 
+		responses <- newWriteResponse(wreqs[writeTarget].seriesIDs, nil)
+	}
+	for writeTarget := range wreqs {
+		if writeTarget.endpoint == h.options.Endpoint {
+			continue
+		}
+		wg.Add(1)
 		// Make a request to the specified endpoint.
 		go func(writeTarget endpointReplica) {
 			defer wg.Done()


### PR DESCRIPTION
* receive/handler: fix label names/values race

There is a label name/value race in the current loop because `labelpb.ReAllocZLabelsStrings(&t.Labels, r.opts.Intern)` might be called which overwrites the original labels. At the same time, we might also be forwarding the same request through gRPC to other Receive nodes.

Fixes the following race:

<details>
<summary>Trace of the race</summary>

10:53:51 receive-1: WARNING: DATA RACE
10:53:51 receive-1: Read at 0x00c001097b90 by goroutine 361:
10:53:51 receive-1: github.com/thanos-io/thanos/pkg/store/labelpb.(*ZLabel).Size()
10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/store/labelpb/label.go:273 +0x35
10:53:51 receive-1: github.com/thanos-io/thanos/pkg/store/storepb/prompb.(*TimeSeries).MarshalToSizedBuffer()
10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/store/storepb/prompb/types.pb.go:1499 +0x7c4
10:53:51 receive-1: github.com/thanos-io/thanos/pkg/store/storepb.(*WriteRequest).MarshalToSizedBuffer()
10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:1318 +0x409
10:53:51 receive-1: github.com/thanos-io/thanos/pkg/store/storepb.(*WriteRequest).Marshal()
10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/store/storepb/rpc.pb.go:1286 +0x64
10:53:51 receive-1: google.golang.org/protobuf/internal/impl.legacyMarshal()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/protobuf@v1.31.0/internal/impl/legacy_message.go:402 +0xb1
10:53:51 receive-1: google.golang.org/protobuf/proto.MarshalOptions.marshal()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/protobuf@v1.31.0/proto/encode.go:166 +0x3a2
10:53:51 receive-1: google.golang.org/protobuf/proto.MarshalOptions.MarshalAppend()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/protobuf@v1.31.0/proto/encode.go:125 +0x96
10:53:51 receive-1: github.com/golang/protobuf/proto.marshalAppend()
10:53:51 receive-1: /go/pkg/mod/github.com/golang/protobuf@v1.5.3/proto/wire.go:40 +0xce
10:53:51 receive-1: github.com/golang/protobuf/proto.Marshal()
10:53:51 receive-1: /go/pkg/mod/github.com/golang/protobuf@v1.5.3/proto/wire.go:23 +0x65
10:53:51 receive-1: google.golang.org/grpc/encoding/proto.codec.Marshal()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/grpc@v1.45.0/encoding/proto/proto.go:45 +0x66
10:53:51 receive-1: google.golang.org/grpc/encoding/proto.(*codec).Marshal()
10:53:51 receive-1: <autogenerated>:1 +0x53
10:53:51 receive-1: google.golang.org/grpc.encode()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/grpc@v1.45.0/rpc_util.go:594 +0x64
10:53:51 receive-1: google.golang.org/grpc.prepareMsg()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:1610 +0x1a8
10:53:51 receive-1: google.golang.org/grpc.(*clientStream).SendMsg()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/grpc@v1.45.0/stream.go:791 +0x284
10:53:51 receive-1: google.golang.org/grpc.invoke()
10:53:51 receive-1: /go/pkg/mod/google.golang.org/grpc@v1.45.0/call.go:70 +0xf2

...
10:53:51 receive-1: Previous write at 0x00c001097b90 by goroutine 357: 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/store/labelpb.ReAllocZLabelsStrings() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/store/labelpb/label.go:69 +0x25e 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Writer).Write() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/writer.go:144 +0x13e4 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2.1() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:672 +0x153 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/tracing.DoInSpan() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/tracing/tracing.go:95 +0x125 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func2() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:671 +0x1fd 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward.func6() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:682 +0x61 10:53:51 receive-1: Goroutine 361 (running) created at: 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).fanoutForward() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:688 +0x9c7 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).forward() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:612 +0x53a 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).handleRequest() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:417 +0xca8 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).receiveHTTP() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:539 +0x1d89 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).receiveHTTP-fm() 10:53:51 receive-1: <autogenerated>:1 +0x51
10:53:51 receive-1: net/http.HandlerFunc.ServeHTTP() 10:53:51 receive-1: /usr/local/go/src/net/http/server.go:2136 +0x47 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.NewHandler.RequestID.func2() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/server/http/middleware/request_id.go:40 +0x191 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/receive.(*Handler).testReady-fm.(*Handler).testReady.func1() 10:53:51 receive-1: /go/src/github.com/thanos-io/thanos/pkg/receive/handler.go:263 +0x249 10:53:51 receive-1: net/http.HandlerFunc.ServeHTTP() 10:53:51 receive-1: /usr/local/go/src/net/http/server.go:2136 +0x47 10:53:51 receive-1: github.com/thanos-io/thanos/pkg/extprom/http.httpInstrumentationHandler.func1()

</details>



* receive/handler: remove break

