### PR TITLE
receive: respect forward timeout in http handler buckets

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -196,10 +196,20 @@ func NewHandler(logger log.Logger, o *Options) *Handler {
 
 	ins := extpromhttp.NewNopInstrumentationMiddleware()
 	if o.Registry != nil {
+		var buckets = []float64{0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5}
+
+		const bucketIncrement = 2.0
+		for curMax := 5.0 + bucketIncrement; curMax < o.ForwardTimeout.Seconds(); curMax += bucketIncrement {
+			buckets = append(buckets, curMax)
+		}
+		if buckets[len(buckets)-1] < o.ForwardTimeout.Seconds() {
+			buckets = append(buckets, o.ForwardTimeout.Seconds())
+		}
+
 		ins = extpromhttp.NewTenantInstrumentationMiddleware(
 			o.TenantHeader,
 			o.Registry,
-			[]float64{0.001, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5},
+			buckets,
 		)
 	}
 


### PR DESCRIPTION
Forward timeout is what ultimately decides how long a HTTP request might take so it doesn't make sense to hard-code max value of 5. In this pull request I propose respecting the configured forward timeout and adding extra buckets if the default buckets don't cover it completely.
