### PR TITLE
receive/handler: allow setting tenant in labelset

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/model/relabel"
 	"github.com/prometheus/prometheus/storage"
@@ -64,6 +65,8 @@ const (
 	// Labels for metrics.
 	labelSuccess = "success"
 	labelError   = "error"
+
+	metaLabelTenantID = model.MetaLabelPrefix + "tenant_id"
 )
 
 var (
@@ -827,7 +830,7 @@ func (h *Handler) sendWrites(
 func (h *Handler) sendLocalWrite(
 	ctx context.Context,
 	writeDestination endpointReplica,
-	tenant string,
+	tenantHTTP string,
 	trackedSeries trackedSeries,
 	responses chan<- writeResponse,
 ) {
@@ -835,16 +838,32 @@ func (h *Handler) sendLocalWrite(
 	defer span.Finish()
 	span.SetTag("endpoint", writeDestination.endpoint)
 	span.SetTag("replica", writeDestination.replica)
-	err := h.writer.Write(tracingCtx, tenant, &prompb.WriteRequest{
-		Timeseries: trackedSeries.timeSeries,
-	})
-	if err != nil {
-		span.SetTag("error", true)
-		span.SetTag("error.msg", err.Error())
-		responses <- newWriteResponse(trackedSeries.seriesIDs, err, writeDestination)
-		return
+
+	tenantSeriesMapping := map[string][]prompb.TimeSeries{}
+	for _, ts := range trackedSeries.timeSeries {
+		lbls := labelpb.ZLabelsToPromLabels(ts.Labels)
+		if tenant := lbls.Get(metaLabelTenantID); tenant != "" {
+			tenantSeriesMapping[tenant] = append(tenantSeriesMapping[tenant], ts)
+			continue
+		} else {
+			tenantSeriesMapping[tenantHTTP] = append(tenantSeriesMapping[tenantHTTP], ts)
+			continue
+		}
+	}
+
+	for tenant, series := range tenantSeriesMapping {
+		err := h.writer.Write(tracingCtx, tenant, &prompb.WriteRequest{
+			Timeseries: series,
+		})
+		if err != nil {
+			span.SetTag("error", true)
+			span.SetTag("error.msg", err.Error())
+			responses <- newWriteResponse(trackedSeries.seriesIDs, err, writeDestination)
+			return
+		}
 	}
 	responses <- newWriteResponse(trackedSeries.seriesIDs, nil, writeDestination)
+
 }
 
 // sendRemoteWrite sends a write request to the remote node. It takes care of checking wether the endpoint is up or not


### PR DESCRIPTION
Add a PoC for setting tenant through the labels contained in each time series. Goal is to reduce requests per second.
