### PR TITLE
receive/handler: update tenant label

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prometheus/common/model"
 	"github.com/prometheus/common/route"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/model/relabel"
@@ -67,7 +66,7 @@ const (
 	labelSuccess = "success"
 	labelError   = "error"
 
-	metaLabelTenantID = model.MetaLabelPrefix + "tenant_id"
+	metaLabelTenantID = "thanos_tenant_id"
 )
 
 var (


### PR DESCRIPTION
After relabeling_configs section Prometheus drops all labels that start with `__`. Technically we could move adding of `__meta_tenant_id` to `metric_relabel_configs` but then meta-metric like `up` and others do not have that `__meta_tenant_id` because, apparently, Prometheus takes labels from after the `relabel_configs` section. Hence, let's just add something human-readable. It doesn't matter much either way to the user because this label gets removed.
