### PR TITLE
*: pull cache key change

### DIFF
--- a/pkg/cache/caching_bucket_config.go
+++ b/pkg/cache/caching_bucket_config.go
@@ -74,8 +74,9 @@ type OperationConfig struct {
 // Operation-specific configs.
 type IterConfig struct {
 	OperationConfig
-	TTL   time.Duration
-	Codec IterCodec
+	TTL        time.Duration
+	Codec      IterCodec
+	ConfigHash string
 }
 
 type ExistsConfig struct {
@@ -115,11 +116,12 @@ func newOperationConfig(cache Cache, matcher func(string) bool) OperationConfig 
 }
 
 // CacheIter configures caching of "Iter" operation for matching directories.
-func (cfg *CachingBucketConfig) CacheIter(configName string, cache Cache, matcher func(string) bool, ttl time.Duration, codec IterCodec) {
+func (cfg *CachingBucketConfig) CacheIter(configName string, cache Cache, matcher func(string) bool, ttl time.Duration, codec IterCodec, configHash string) {
 	cfg.iter[configName] = &IterConfig{
 		OperationConfig: newOperationConfig(cache, matcher),
 		TTL:             ttl,
 		Codec:           codec,
+		ConfigHash:      configHash,
 	}
 }
 

--- a/pkg/store/cache/cachekey/cachekey_test.go
+++ b/pkg/store/cache/cachekey/cachekey_test.go
@@ -71,6 +71,24 @@ func TestParseBucketCacheKey(t *testing.T) {
 			expected:    BucketCacheKey{},
 			expectedErr: ErrInvalidBucketCacheKeyFormat,
 		},
+		// Iter could have object storage hash attached to it.
+		{
+			key: "iter::asdasdsa",
+			expected: BucketCacheKey{
+				Verb:                    IterVerb,
+				Name:                    "",
+				ObjectStorageConfigHash: "asdasdsa",
+			},
+		},
+		// Iter recursive could have object storage hash attached to it.
+		{
+			key: "iter-recursive:foo/:asdasdsa",
+			expected: BucketCacheKey{
+				Verb:                    IterRecursiveVerb,
+				Name:                    "foo/",
+				ObjectStorageConfigHash: "asdasdsa",
+			},
+		},
 		// Key must always have a name.
 		{
 			key:         "iter",
@@ -116,8 +134,10 @@ func TestParseBucketCacheKey(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res, err := ParseBucketCacheKey(tc.key)
-		testutil.Equals(t, tc.expectedErr, err)
-		testutil.Equals(t, tc.expected, res)
+		t.Run(tc.key, func(t *testing.T) {
+			res, err := ParseBucketCacheKey(tc.key)
+			testutil.Equals(t, tc.expectedErr, err)
+			testutil.Equals(t, tc.expected, res)
+		})
 	}
 }

--- a/pkg/store/cache/caching_bucket.go
+++ b/pkg/store/cache/caching_bucket.go
@@ -133,7 +133,7 @@ func (cb *CachingBucket) Iter(ctx context.Context, dir string, f func(string) er
 
 	cb.operationRequests.WithLabelValues(objstore.OpIter, cfgName).Inc()
 
-	iterVerb := cachekey.BucketCacheKey{Verb: cachekey.IterVerb, Name: dir}
+	iterVerb := cachekey.BucketCacheKey{Verb: cachekey.IterVerb, Name: dir, ObjectStorageConfigHash: cfg.ConfigHash}
 	opts := objstore.ApplyIterOptions(options...)
 	if opts.Recursive {
 		iterVerb.Verb = cachekey.IterRecursiveVerb

--- a/pkg/store/cache/caching_bucket_test.go
+++ b/pkg/store/cache/caching_bucket_test.go
@@ -400,7 +400,7 @@ func TestCachedIter(t *testing.T) {
 
 	const cfgName = "dirs"
 	cfg := thanoscache.NewCachingBucketConfig()
-	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute, JSONIterCodec{})
+	cfg.CacheIter(cfgName, cache, func(string) bool { return true }, 5*time.Minute, JSONIterCodec{}, "")
 
 	cb, err := NewCachingBucket(inmem, cfg, nil, nil)
 	testutil.Ok(t, err)


### PR DESCRIPTION
It is not possible currently to run multiple Thanos versions on one server i.e. it is a global setting so let's pull an old fix before upgrading everything to 0.34.0/0.35.0.