### PR TITLE
receive: fix maxBufferedResponses calculation

### DIFF
--- a/pkg/receive/handler_test.go
+++ b/pkg/receive/handler_test.go
@@ -1692,7 +1692,7 @@ func TestDistributeSeries(t *testing.T) {
 	hr := &hashringSeenTenants{Hashring: hashring}
 	h.Hashring(hr)
 
-	_, remote, err := h.distributeTimeseriesToReplicas(
+	_, remote, maxBufferedResponses, err := h.distributeTimeseriesToReplicas(
 		[]wreqTenantTuple{
 			{
 				tenant: "foo",
@@ -1714,6 +1714,7 @@ func TestDistributeSeries(t *testing.T) {
 	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["bar"].timeSeries[0].Labels).Len())
 	require.Equal(t, 1, labelpb.ZLabelsToPromLabels(remote[endpointReplica{endpoint: "http://localhost:9090", replica: 0}]["boo"].timeSeries[0].Labels).Len())
 	require.Equal(t, map[string]struct{}{"bar": {}, "boo": {}}, hr.seenTenants)
+	require.Equal(t, 1, maxBufferedResponses)
 }
 
 func TestHandlerFlippingHashrings(t *testing.T) {

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -1008,11 +1008,21 @@ func TestReceiveExtractsTenant(t *testing.T) {
 						{Value: 1, Timestamp: time.Now().UnixMilli()},
 					},
 				},
+				{
+					Labels: []prompb.Label{
+						{Name: "thanos_tenant_id", Value: "tenant-2"},
+						{Name: "bb", Value: "cc"},
+					},
+					Samples: []prompb.Sample{
+						{Value: 1, Timestamp: time.Now().UnixMilli()},
+					},
+				},
 			},
 		})
 	}))
 
 	testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "tenant-1")), e2emon.WaitMissingMetrics()))
+	testutil.Ok(t, i.WaitSumMetricsWithOptions(e2emon.Equals(0), []string{"prometheus_tsdb_blocks_loaded"}, e2emon.WithLabelMatchers(matchers.MustNewMatcher(matchers.MatchEqual, "tenant", "tenant-2")), e2emon.WaitMissingMetrics()))
 }
 
 func TestReceiveGlob(t *testing.T) {


### PR DESCRIPTION
Fix maxBufferedResponses calculation to take into account that there could be multiple writes in one local write and that one remote write might contain data from multiple tenants.
