### PR TITLE
receive/handler: fix time series calculation

### DIFF
--- a/pkg/receive/handler.go
+++ b/pkg/receive/handler.go
@@ -747,7 +747,6 @@ func (h *Handler) fanoutForward(ctx context.Context, params remoteWriteParams) (
 			tenants.WriteString(", ")
 		}
 	}
-	numTimeseries *= len(params.replicas)
 
 	logTags := []interface{}{"tenants", tenants.String()}
 	if id, ok := middleware.RequestIDFromContext(ctx); ok {
@@ -883,10 +882,10 @@ func (h *Handler) distributeTimeseriesToReplicas(
 
 				tenantSeries.timeSeries = append(tenantSeries.timeSeries, ts)
 				tenantSeries.seriesIDs = append(tenantSeries.seriesIDs, seriesID)
-				seriesID++
 
 				writeDestination[endpointReplica][tenant] = tenantSeries
 			}
+			seriesID++
 		}
 	}
 


### PR DESCRIPTION
Fix time series id calculation - we were bumping series ID for each replica whereas the ID needs to identify the unique time series. Add case to cover this scenario.
