### PR TITLE
*: reduce CPU usage

### DIFF
--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -99,12 +99,18 @@ func NewMultiTSDB(
 type localClient struct {
 	storepb.StoreClient
 	store *store.TSDBStore
+	desc  string
 }
 
 func newLocalClient(c storepb.StoreClient, store *store.TSDBStore) *localClient {
+	mint, maxt := store.TimeRange()
 	return &localClient{
 		StoreClient: c,
 		store:       store,
+		desc: fmt.Sprintf(
+			"LabelSets: %v MinTime: %d MaxTime: %d",
+			labelpb.PromLabelSetsToString(labelpb.ZLabelSetsToPromLabelSets(store.LabelSet()...)), mint, maxt,
+		),
 	}
 }
 
@@ -133,11 +139,7 @@ func (l *localClient) TSDBInfos() []infopb.TSDBInfo {
 }
 
 func (l *localClient) String() string {
-	mint, maxt := l.store.TimeRange()
-	return fmt.Sprintf(
-		"LabelSets: %v MinTime: %d MaxTime: %d",
-		labelpb.PromLabelSetsToString(l.LabelSets()), mint, maxt,
-	)
+	return l.desc
 }
 
 func (l *localClient) Addr() (string, bool) {

--- a/pkg/store/proxy_heap.go
+++ b/pkg/store/proxy_heap.go
@@ -505,7 +505,7 @@ func newAsyncRespSet(
 	var closeSeries context.CancelFunc
 
 	storeAddr, isLocalStore := st.Addr()
-	storeID := labelpb.PromLabelSetsToString(st.LabelSets())
+	storeID := st.String()
 	if storeID == "" {
 		storeID = "Store Gateway"
 	}
@@ -556,7 +556,7 @@ func newAsyncRespSet(
 		return newLazyRespSet(
 			span,
 			frameTimeout,
-			st.String(),
+			storeID,
 			st.LabelSets(),
 			closeSeries,
 			cl,
@@ -568,7 +568,7 @@ func newAsyncRespSet(
 		return newEagerRespSet(
 			span,
 			frameTimeout,
-			st.String(),
+			storeID,
 			st.LabelSets(),
 			closeSeries,
 			cl,

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -410,9 +410,13 @@ func (mc *matchersCache) convertMatchers(ms ...LabelMatcher) ([]*labels.Matcher,
 }
 
 func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
-	hasher := mc.hasherPool.Get().(*xxhash.Digest)
-	if hasher == nil {
+	var hasher *xxhash.Digest
+
+	hasherPooled := mc.hasherPool.Get()
+	if hasherPooled == nil {
 		hasher = xxhash.New()
+	} else {
+		hasher = hasherPooled.(*xxhash.Digest)
 	}
 	hasher.Reset()
 	defer mc.hasherPool.Put(hasher)

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -409,6 +409,13 @@ func (mc *matchersCache) convertMatchers(ms ...LabelMatcher) ([]*labels.Matcher,
 	return res, nil
 }
 
+func copyMatcherSlice(in []*labels.Matcher) []*labels.Matcher {
+	out := make([]*labels.Matcher, 0, len(in))
+	out = append(out, in...)
+
+	return out
+}
+
 func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher, error) {
 	var hasher *xxhash.Digest
 
@@ -431,7 +438,7 @@ func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher
 	h := hasher.Sum64()
 
 	if val, ok := mc.c.Get(h); ok {
-		return val.([]*labels.Matcher), nil
+		return copyMatcherSlice(val.([]*labels.Matcher)), nil
 	}
 
 	convert, err := mc.convertMatchers(ms...)
@@ -440,7 +447,7 @@ func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher
 	}
 
 	mc.c.Add(h, convert)
-	return convert, nil
+	return copyMatcherSlice(convert), nil
 }
 
 func mustNewLRU() *lru.Cache {

--- a/pkg/store/storepb/custom.go
+++ b/pkg/store/storepb/custom.go
@@ -418,10 +418,10 @@ func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher
 	defer mc.hasherPool.Put(hasher)
 
 	for _, m := range ms {
-		hasher.WriteString(m.Name)
-		hasher.WriteString(m.Value)
+		_, _ = hasher.WriteString(m.Name)
+		_, _ = hasher.WriteString(m.Value)
 		// NOTE(GiedriusS): these can only be 0-4 so we can safely cast to byte.
-		hasher.Write([]byte{byte(m.Type)})
+		_, _ = hasher.Write([]byte{byte(m.Type)})
 	}
 
 	h := hasher.Sum64()
@@ -439,7 +439,7 @@ func (mc *matchersCache) getOrSetMatchers(ms ...LabelMatcher) ([]*labels.Matcher
 	return convert, nil
 }
 
-func mustNewLRU(size int) *lru.Cache {
+func mustNewLRU() *lru.Cache {
 	var lruSize int
 
 	lruSizeParam := os.Getenv("THANOS_LRU_SIZE")
@@ -461,7 +461,7 @@ func mustNewLRU(size int) *lru.Cache {
 }
 
 var mc *matchersCache = &matchersCache{
-	c: mustNewLRU(1000),
+	c: mustNewLRU(),
 }
 
 // MatchersToPromMatchers returns Prometheus matchers from proto matchers.


### PR DESCRIPTION
Reduce CPU usage by not allocating a String constantly. Add LRU cache for the matchers conversion. First doing this in a hacky way to see how much CPU usage drops.
