### PR TITLE
receive/multitsdb: add cuckoo filter on metric names

### DIFF
--- a/.bingo/gotesplit.sum
+++ b/.bingo/gotesplit.sum
@@ -1,4 +1,6 @@
 github.com/Songmu/gotesplit v0.2.1 h1:qJFvR75nJpeKyMQFwyDtFrcc6zDWhrHAkks7DvM8oLo=
 github.com/Songmu/gotesplit v0.2.1/go.mod h1:sVBfmLT26b1H5VhUpq8cRhCVK75GAmW9c8r2NiK0gzk=
 github.com/jstemmer/go-junit-report v1.0.0 h1:8X1gzZpR+nVQLAht+L/foqOeX2l9DTZoaIPbEQHxsds=
+github.com/jstemmer/go-junit-report v1.0.0/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/go.mod
+++ b/go.mod
@@ -120,6 +120,7 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/onsi/gomega v1.27.10
 	github.com/prometheus-community/prom-label-proxy v0.7.0
+	github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb
 	go.opentelemetry.io/contrib/propagators/autoprop v0.38.0
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb
 	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
@@ -127,6 +128,7 @@ require (
 
 require (
 	github.com/bboreham/go-loser v0.0.0-20230920113527-fcc2c21820a3 // indirect
+	github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 // indirect
 	github.com/go-openapi/runtime v0.26.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.0.0 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/dennwc/varint v1.0.0 h1:kGNFFSSw8ToIy3obO/kKr8U9GZYUAxQEVuix4zfDWzE=
 github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgziApxA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165 h1:BS21ZUJ/B5X2UVUbczfmdWH7GapPWAhxcMsDnjJTU1E=
+github.com/dgryski/go-metro v0.0.0-20200812162917-85c65e2d0165/go.mod h1:c9O8+fpSOX1DM8cPNSkX/qsBWdkD4yd2dpciOWQjpBw=
 github.com/digitalocean/godo v1.106.0 h1:m5iErwl3xHovGFlawd50n54ntgXHt1BLsvU6BXsVxEU=
 github.com/digitalocean/godo v1.106.0/go.mod h1:R6EmmWI8CT1+fCtjWY9UCB+L5uufuZH13wk3YhxycCs=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
@@ -918,6 +920,8 @@ github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrY
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21 h1:yWfiTPwYxB0l5fGMhl/G+liULugVIHD9AU77iNLrURQ=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.21/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb h1:XfLJSPIOUX+osiMraVgIrMR27uMXnRJWGm1+GL8/63U=
+github.com/seiflotfy/cuckoofilter v0.0.0-20220411075957-e3b120b3f5fb/go.mod h1:bR6DqgcAl1zTcOX8/pE2Qkj9XO00eCNqmKb7lXP8EAg=
 github.com/sercand/kuberesolver v2.4.0+incompatible h1:WE2OlRf6wjLxHwNkkFLQGaZcVLEXjMjBPjjEU5vksH8=
 github.com/sercand/kuberesolver v2.4.0+incompatible/go.mod h1:lWF3GL0xptCB/vCiJPl/ZshwPsX/n4Y7u0CW9E7aQIQ=
 github.com/shirou/gopsutil/v3 v3.21.2/go.mod h1:ghfMypLDrFSWN2c9cDYFLHyynQ+QUht0cv/18ZqVczw=

--- a/pkg/filter/cuckoo.go
+++ b/pkg/filter/cuckoo.go
@@ -1,0 +1,49 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
+package filter
+
+import (
+	"sync"
+
+	cuckoo "github.com/seiflotfy/cuckoofilter"
+)
+
+type MetricNameFilter interface {
+	MatchesMetricName(metricName string) bool
+	ResetAddMetricName(metricNames ...string)
+}
+
+type AllowAllMetricNameFilter struct{}
+
+func (f AllowAllMetricNameFilter) MatchesMetricName(metricName string) bool {
+	return true
+}
+
+func (f AllowAllMetricNameFilter) ResetAddMetricName(metricNames ...string) {}
+
+type CuckooFilterMetricNameFilter struct {
+	filter *cuckoo.Filter
+	mtx    sync.RWMutex
+}
+
+func NewCuckooFilterMetricNameFilter(capacity uint) *CuckooFilterMetricNameFilter {
+	return &CuckooFilterMetricNameFilter{
+		filter: cuckoo.NewFilter(capacity),
+	}
+}
+
+func (f *CuckooFilterMetricNameFilter) MatchesMetricName(metricName string) bool {
+	f.mtx.RLock()
+	defer f.mtx.RUnlock()
+	return f.filter.Lookup([]byte(metricName))
+}
+
+func (f *CuckooFilterMetricNameFilter) ResetAddMetricName(metricNames ...string) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.filter.Reset()
+	for _, metricName := range metricNames {
+		f.filter.Insert([]byte(metricName))
+	}
+}

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -14,6 +14,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/thanos-io/thanos/pkg/api/query/querypb"
+	"github.com/thanos-io/thanos/pkg/filter"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -636,6 +637,7 @@ func (e *EndpointSet) GetEndpointStatus() []EndpointStatus {
 
 type endpointRef struct {
 	storepb.StoreClient
+	filter.AllowAllMetricNameFilter
 
 	mtx      sync.RWMutex
 	cc       *grpc.ClientConn

--- a/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
+++ b/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/thanos-io/thanos/pkg/component"
+	"github.com/thanos-io/thanos/pkg/filter"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/runutil"
 	"github.com/thanos-io/thanos/pkg/store"
@@ -169,6 +170,7 @@ func NewStoreSet(
 
 type storeRef struct {
 	storepb.StoreClient
+	filter.AllowAllMetricNameFilter
 
 	mtx  sync.RWMutex
 	cc   *grpc.ClientConn

--- a/pkg/store/storepb/testutil/client.go
+++ b/pkg/store/storepb/testutil/client.go
@@ -6,12 +6,14 @@ package storetestutil
 import (
 	"github.com/prometheus/prometheus/model/labels"
 
+	"github.com/thanos-io/thanos/pkg/filter"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/store/storepb"
 )
 
 type TestClient struct {
 	storepb.StoreClient
+	filter.AllowAllMetricNameFilter
 
 	Name string
 

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -1544,7 +1544,7 @@ func checkNetworkRequests(t *testing.T, addr string) {
 	ctx, cancel := chromedp.NewContext(new(emptyCtx))
 	t.Cleanup(cancel)
 
-	testutil.Ok(t, runutil.Retry(1*time.Minute, ctx.Done(), func() error {
+	testutil.Ok(t, runutil.RetryWithLog(log.NewLogfmtLogger(os.Stderr), 1*time.Second, ctx.Done(), func() error {
 		var networkErrors []string
 
 		// Listen for failed network requests and push them to an array.


### PR DESCRIPTION
Add a cuckoo filter on metric names to reduce fan-out cost. About 3x reduction.

![Screenshot from 2024-06-06 15-51-28](https://github.com/vinted/thanos/assets/2377233/163febeb-3c9f-4f4e-8a72-0ebe04dcae99)
