### PR TITLE
discovery/dns: resolve again if err happens

### DIFF
--- a/pkg/discovery/dns/grpc.go
+++ b/pkg/discovery/dns/grpc.go
@@ -86,7 +86,10 @@ func (r *resolver) run() {
 				raddr := grpcresolver.Address{Addr: addr}
 				state.Addresses = append(state.Addresses, raddr)
 			}
-			_ = r.cc.UpdateState(state)
+			err = r.cc.UpdateState(state)
+			if err != nil {
+				continue
+			}
 		}
 		select {
 		case <-r.ctx.Done():


### PR DESCRIPTION
UpdateState() docs say that if an error happens then the resolver should try again. Let's do that. Fixes a problem for us in prod.
