### PR TITLE
query: add rm replica labels functionality

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -106,6 +106,10 @@ func registerQuery(app *extkingpin.App) {
 
 	queryReplicaLabels := cmd.Flag("query.replica-label", "Labels to treat as a replica indicator along which data is deduplicated. Still you will be able to query without deduplication using 'dedup=false' parameter. Data includes time series, recording rules, and alerting rules. Flag may be specified multiple times as well as a comma separated list of labels.").
 		Strings()
+
+	queryReplicaRmLabels := cmd.Flag("query.rm-replica-label", "Replica labels to delete from QueryAPI calls. Experimental.").
+		Strings()
+
 	queryPartitionLabels := cmd.Flag("query.partition-label", "Labels that partition the leaf queriers. This is used to scope down the labelsets of leaf queriers when using the distributed query mode. If set, these labels must form a partition of the leaf queriers. Partition labels must not intersect with replica labels. Every TSDB of a leaf querier must have these labels. This is useful when there are multiple external labels that are irrelevant for the partition as it allows the distributed engine to ignore them for some optimizations. If this is empty then all labels are used as partition labels.").Strings()
 
 	// currently, we choose the highest MinT of an engine when querying multiple engines. This flag allows to change this behavior to choose the lowest MinT.
@@ -337,6 +341,7 @@ func registerQuery(app *extkingpin.App) {
 			*enforceTenancy,
 			*tenantLabel,
 			*queryDistributedWithOverlappingInterval,
+			*queryReplicaRmLabels,
 		)
 	})
 }
@@ -399,6 +404,7 @@ func runQuery(
 	enforceTenancy bool,
 	tenantLabel string,
 	queryDistributedWithOverlappingInterval bool,
+	queryReplicaRmLabels []string,
 ) error {
 	comp := component.Query
 	if alertQueryURL == "" {
@@ -590,7 +596,12 @@ func runQuery(
 		)
 
 		defaultEngineType := querypb.EngineType(querypb.EngineType_value[string(defaultEngine)])
-		grpcAPI := apiv1.NewGRPCAPI(time.Now, queryReplicaLabels, queryableCreator, remoteEndpointsCreator, queryCreator, defaultEngineType, lookbackDeltaCreator, instantDefaultMaxSourceResolution)
+
+		rmReplicaLabels := map[string]struct{}{}
+		for _, label := range queryReplicaRmLabels {
+			rmReplicaLabels[label] = struct{}{}
+		}
+		grpcAPI := apiv1.NewGRPCAPI(time.Now, queryReplicaLabels, rmReplicaLabels, queryableCreator, remoteEndpointsCreator, queryCreator, defaultEngineType, lookbackDeltaCreator, instantDefaultMaxSourceResolution)
 		s := grpcserver.New(logger, reg, tracer, grpcLogOpts, logFilterMethods, comp, grpcProbe,
 			grpcserver.WithServer(apiv1.RegisterQueryServer(grpcAPI)),
 			grpcserver.WithServer(store.RegisterStoreServer(seriesProxy, logger)),

--- a/pkg/api/query/grpc.go
+++ b/pkg/api/query/grpc.go
@@ -33,11 +33,13 @@ type GRPCAPI struct {
 	defaultEngine               querypb.EngineType
 	lookbackDeltaCreate         func(int64) time.Duration
 	defaultMaxResolutionSeconds time.Duration
+	rmReplicaLabels             map[string]struct{}
 }
 
 func NewGRPCAPI(
 	now func() time.Time,
 	replicaLabels []string,
+	rmReplicaLabels map[string]struct{},
 	queryableCreator query.QueryableCreator,
 	remoteEndpointsCreator query.RemoteEndpointsCreator,
 	queryCreator queryCreator,
@@ -54,6 +56,7 @@ func NewGRPCAPI(
 		defaultEngine:               defaultEngine,
 		lookbackDeltaCreate:         lookbackDeltaCreate,
 		defaultMaxResolutionSeconds: defaultMaxResolutionSeconds,
+		rmReplicaLabels:             rmReplicaLabels,
 	}
 }
 
@@ -88,9 +91,16 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 		replicaLabels = request.ReplicaLabels
 	}
 
+	rlabels := make([]string, 0, len(replicaLabels))
+	for _, lbl := range replicaLabels {
+		if _, ok := g.rmReplicaLabels[lbl]; !ok {
+			rlabels = append(rlabels, lbl)
+		}
+	}
+
 	queryable := g.queryableCreate(
 		request.EnableDedup,
-		replicaLabels,
+		rlabels,
 		storeMatchers,
 		maxResolution,
 		request.EnablePartialResponse,
@@ -100,7 +110,7 @@ func (g *GRPCAPI) Query(request *querypb.QueryRequest, server querypb.Query_Quer
 	)
 
 	remoteEndpoints := g.remoteEndpointsCreate(
-		replicaLabels,
+		rlabels,
 		request.EnablePartialResponse,
 	)
 
@@ -186,9 +196,16 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 		replicaLabels = request.ReplicaLabels
 	}
 
+	rlabels := make([]string, 0, len(replicaLabels))
+	for _, lbl := range replicaLabels {
+		if _, ok := g.rmReplicaLabels[lbl]; !ok {
+			rlabels = append(rlabels, lbl)
+		}
+	}
+
 	queryable := g.queryableCreate(
 		request.EnableDedup,
-		replicaLabels,
+		rlabels,
 		storeMatchers,
 		maxResolution,
 		request.EnablePartialResponse,
@@ -198,7 +215,7 @@ func (g *GRPCAPI) QueryRange(request *querypb.QueryRangeRequest, srv querypb.Que
 	)
 
 	remoteEndpoints := g.remoteEndpointsCreate(
-		replicaLabels,
+		rlabels,
 		request.EnablePartialResponse,
 	)
 

--- a/pkg/api/query/grpc_test.go
+++ b/pkg/api/query/grpc_test.go
@@ -35,7 +35,7 @@ func TestGRPCQueryAPIWithQueryPlan(t *testing.T) {
 	queryableCreator := query.NewQueryableCreator(logger, reg, proxy, 1, 1*time.Minute, dedup.AlgorithmPenalty)
 	remoteEndpointsCreator := query.NewRemoteEndpointsCreator(logger, func() []query.Client { return nil }, nil, 1*time.Minute, true, true)
 	lookbackDeltaFunc := func(i int64) time.Duration { return 5 * time.Minute }
-	api := NewGRPCAPI(time.Now, nil, queryableCreator, remoteEndpointsCreator, queryFactory, querypb.EngineType_thanos, lookbackDeltaFunc, 0)
+	api := NewGRPCAPI(time.Now, nil, nil, queryableCreator, remoteEndpointsCreator, queryFactory, querypb.EngineType_thanos, lookbackDeltaFunc, 0)
 
 	expr, err := extpromql.ParseExpr("metric")
 	testutil.Ok(t, err)
@@ -98,7 +98,7 @@ func TestGRPCQueryAPIErrorHandling(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		api := NewGRPCAPI(time.Now, nil, queryableCreator, remoteEndpointsCreator, test.queryCreator, querypb.EngineType_prometheus, lookbackDeltaFunc, 0)
+		api := NewGRPCAPI(time.Now, nil, nil, queryableCreator, remoteEndpointsCreator, test.queryCreator, querypb.EngineType_prometheus, lookbackDeltaFunc, 0)
 		t.Run("range_query", func(t *testing.T) {
 			rangeRequest := &querypb.QueryRangeRequest{
 				Query:            "metric",


### PR DESCRIPTION
Add the ability to remove some replica labels from the QueryAPI. The purpose is to allow the dedup operator to work properly.
